### PR TITLE
🐛 Fix activity condition

### DIFF
--- a/src/Models/Primitives/Activity.php
+++ b/src/Models/Primitives/Activity.php
@@ -59,7 +59,7 @@
          */
         public function __construct($activity)
         {
-            if (!in_array($activity, $this->activityLevel))
+            if (!in_array($activity, array_keys($this->activityLevel)))
             {
                 throw new InvalidActivityLevel();
             }


### PR DESCRIPTION
Before the last changes, it worked fine because the first array element was 0. Now it doesn't work.